### PR TITLE
CreateTokenForCreditCardAction should set the Token into CreateTokenForCreditCard

### DIFF
--- a/src/Payum/Stripe/Action/CreateTokenForCreditCardAction.php
+++ b/src/Payum/Stripe/Action/CreateTokenForCreditCardAction.php
@@ -41,8 +41,11 @@ class CreateTokenForCreditCardAction extends GatewayAwareAction
         $token['card'] = $cardData;
 
         $this->gateway->execute(new CreateToken($token));
-
-        $request->setToken($token->toUnsafeArray());
+        $token = $token->toUnsafeArray();
+        $request->setModel($token);
+        if (isset($token['id'])) {
+            $request->setToken($token['id']);
+        }
     }
 
     /**

--- a/src/Payum/Stripe/Tests/Action/CreateTokenForCreditCardActionTest.php
+++ b/src/Payum/Stripe/Tests/Action/CreateTokenForCreditCardActionTest.php
@@ -105,7 +105,7 @@ class CreateTokenForCreditCardActionTest extends GenericActionTest
         $action->execute($createTokenForCreditCard = new CreateTokenForCreditCard($card));
 
         $token = $createTokenForCreditCard->getToken();
-        $this->assertEquals('myToken', $token['id']);
+        $this->assertEquals('myToken', $token);
     }
 
     /**


### PR DESCRIPTION
It is not the "payum way" to set the whole response from Stripe into as the token and then have to do this: in our code https://github.com/Vreasy/vreasy/compare/WEB-2317?expand=1#diff-927fdbe498bf39174b99053b934e4116R101

Other portals night return something completely different with different structure.
`setToken` MUST receive the token itself.

a TODO here would be to check for errors.
I am not sure what happens when and if `$token['id']`is not set.
Or what to do when that happens